### PR TITLE
engine: do not use keywords as keys

### DIFF
--- a/invenio_classifier/engine.py
+++ b/invenio_classifier/engine.py
@@ -136,6 +136,8 @@ def get_keywords_output(single_keywords, composite_keywords, taxonomy_name,
     for w in single_keywords_p:
         categories[w[0].concept] = w[0].type
 
+    categories = categories.items()
+
     complete_output = _output_complete(single_keywords_p, composite_keywords_p,
                                        author_keywords, acronyms, spires,
                                        only_core_tags, limit=output_limit)
@@ -352,7 +354,8 @@ def _get_singlekws(skw_matches, spires=False):
     output = {}
     for single_keyword, info in skw_matches:
         output[single_keyword.output(spires)] = len(info[0])
-    return output
+    output = output.items()
+    return sorted(output, key=lambda x: x[1], reverse=True)
 
 
 def _get_compositekws(ckw_matches, spires=False):
@@ -366,7 +369,8 @@ def _get_compositekws(ckw_matches, spires=False):
     for composite_keyword, info in ckw_matches:
         output[composite_keyword.output(spires)] = {"numbers": len(info[0]),
                                                     "details": info[1]}
-    return output
+    output = output.items()
+    return sorted(output, key=lambda x: x[1]['numbers'], reverse=True)
 
 
 def _get_acronyms(acronyms):
@@ -378,7 +382,7 @@ def _get_acronyms(acronyms):
                                         for expansion in expansions])
             acronyms_str[acronym] = expansions_str
 
-    return acronyms
+    return acronyms.items()
 
 
 def _get_author_keywords(author_keywords, spires=False):
@@ -405,7 +409,7 @@ def _get_fieldcodes(skw_matches, ckw_matches, spires=False):
     :var skw_matches: dict of {keyword: [info,...]}
     :var ckw_matches: dict of {keyword: [info,...]}
     :keyword spires: bool, to get the spires output
-    :return: string
+    :return: list of tuples with (fieldcodes, keywords)
     """
     fieldcodes = {}
     output = {}
@@ -428,7 +432,7 @@ def _get_fieldcodes(skw_matches, ckw_matches, spires=False):
     for fieldcode, keywords in fieldcodes.items():
         output[fieldcode] = ', '.join(keywords)
 
-    return output
+    return output.items()
 
 
 def _get_core_keywords(skw_matches, ckw_matches, spires=False):
@@ -437,7 +441,7 @@ def _get_core_keywords(skw_matches, ckw_matches, spires=False):
     :var skw_matches: dict of {keyword: [info,...]}
     :var ckw_matches: dict of {keyword: [info,...]}
     :keyword spires: bool, to get the spires output
-    :return: set of formatted core keywords
+    :return: list of formatted core keywords
     """
     output = {}
     category = {}
@@ -466,7 +470,8 @@ def _get_core_keywords(skw_matches, ckw_matches, spires=False):
                 if c.core:
                     output[c.output(spires)] = info[1][i]
                 i += 1
-    return output
+    output = output.items()
+    return sorted(output, key=lambda x: x[1])
 
 
 def filter_core_keywords(keywords):

--- a/invenio_classifier/extractor.py
+++ b/invenio_classifier/extractor.py
@@ -31,7 +31,6 @@ import re
 import subprocess
 
 import six
-
 from flask import current_app
 
 from .errors import IncompatiblePDF2Text

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -42,15 +42,15 @@ def test_keywords(app, demo_taxonomy, demo_text):
             output_mode="dict"
         )
         output = out.get("complete_output")
-        single_keywords = output.get("single_keywords", {}).keys()
+        single_keywords = output.get("single_keywords", [])
 
         assert len(single_keywords) == 3
-        assert "aberration" in single_keywords
+        assert ("aberration", 2) in single_keywords
 
-        core_keywords = output.get("core_keywords", {}).keys()
+        core_keywords = output.get("core_keywords", [])
 
         assert len(core_keywords) == 2
-        assert "supersymmetry" in core_keywords
+        assert ("supersymmetry", 1) in core_keywords
 
 
 def test_taxonomy_error(app, demo_text):
@@ -73,15 +73,15 @@ def test_file_extration(app, demo_pdf_file, demo_taxonomy):
             output_mode="dict"
         )
         output = out.get("complete_output")
-        single_keywords = output.get("single_keywords", {}).keys()
+        single_keywords = output.get("single_keywords", [])
 
         assert len(single_keywords) == 4
-        assert "gauge field theory Yang-Mills" in single_keywords
+        assert ("gauge field theory Yang-Mills", 9) in single_keywords
 
-        core_keywords = output.get("core_keywords", {}).keys()
+        core_keywords = output.get("core_keywords", [])
 
         assert len(core_keywords) == 3
-        assert "Yang-Mills" in core_keywords
+        assert ("Yang-Mills", 12) in core_keywords
 
 
 def test_author_keywords(app, demo_pdf_file_with_author_keywords,
@@ -128,15 +128,15 @@ def test_taxonomy_workdir(app, demo_text, demo_taxonomy):
             output_mode="dict"
         )
         output = out.get("complete_output")
-        single_keywords = output.get("single_keywords", {}).keys()
+        single_keywords = output.get("single_keywords", [])
 
         assert len(single_keywords) == 3
-        assert "aberration" in single_keywords
+        assert ("aberration", 2) in single_keywords
 
-        core_keywords = output.get("core_keywords", {}).keys()
+        core_keywords = output.get("core_keywords", [])
 
         assert len(core_keywords) == 2
-        assert "supersymmetry" in core_keywords
+        assert ("supersymmetry", 1) in core_keywords
 
 
 def test_rebuild_cache(app, demo_taxonomy):


### PR DESCRIPTION
Do not use keywords as dictionary keys, rather as elements in a list.
(Closes inspirehep/inspire-next#2456)

Signed-off-by: Samuele Kaplun <samuele.kaplun@cern.ch>